### PR TITLE
Fix missing closing quote and semicolon

### DIFF
--- a/bootstrap-sass-styles.loader.js
+++ b/bootstrap-sass-styles.loader.js
@@ -53,7 +53,7 @@ module.exports = function (content) {
   source = start + partials.filter(function (partial) {
     return config.styles[partial];
   }).map(function (partial) {
-    return "@import \"~bootstrap-sass/assets/stylesheets/bootstrap/" + partial;
+    return "@import \"~bootstrap-sass/assets/stylesheets/bootstrap/" + partial + "\";";
   }).join("\n");
   return source;
 }


### PR DESCRIPTION
Newer node-sass versions seem to require a semicolon at the end of the line. Also we need to close the quotes.
